### PR TITLE
Create SeasonStatistics class

### DIFF
--- a/lib/season_helper_module.rb
+++ b/lib/season_helper_module.rb
@@ -116,4 +116,12 @@ module Seasonable
     end
     teams_array.uniq
   end
+
+  def find_team_name_by_id(id_number)
+    team_name = nil
+    @teams_data.each do |row|
+      team_name = row[:teamname] if row[:team_id] == id_number.to_s
+    end
+    team_name
+  end
 end

--- a/lib/season_statistics.rb
+++ b/lib/season_statistics.rb
@@ -1,0 +1,56 @@
+require './lib/stat_tracker'
+require './lib/season_helper_module'
+
+class SeasonStatistics
+  include Seasonable
+
+  attr_reader :season
+
+  def initialize(locations, season)
+    @season = season
+    @locations = locations
+    @games_data = CSV.read(@locations[:games], headers: true, header_converters: :symbol)
+    @teams_data = CSV.read(@locations[:teams], headers: true, header_converters: :symbol)
+    @game_teams_data = CSV.read(@locations[:game_teams], headers: true, header_converters: :symbol)
+  end
+
+  def self.from_csv(locations, season)
+    SeasonStatistics.new(locations, season)
+  end
+
+  def winningest_coach
+    records = coach_records(@season)
+    populate_coach_records(@season, records)
+    winning_record(records).max_by { |team, win_percent| win_percent }[0].to_s
+  end
+
+  def worst_coach
+    records = coach_records(@season)
+    populate_coach_records(@season, records)
+    winning_record(records).min_by { |team, win_percent| win_percent }[0].to_s
+  end
+
+  def most_accurate_team
+    records = accuracy_records(@season)
+    populate_accuracy_records(@season, records)
+    find_team_name_by_id(most_accurate(records))
+  end
+
+  def least_accurate_team
+    records = accuracy_records(@season)
+    populate_accuracy_records(@season, records)
+    find_team_name_by_id(least_accurate(records))
+  end
+
+  def most_tackles
+    records = tackle_records(@season)
+    populate_tackle_records(@season, records)
+    find_team_name_by_id(best_tackling_team(records))
+  end
+
+  def fewest_tackles
+    records = tackle_records(@season)
+    populate_tackle_records(@season, records)
+    find_team_name_by_id(worst_tackling_team(records))
+  end
+end

--- a/spec/season_helper_module_spec.rb
+++ b/spec/season_helper_module_spec.rb
@@ -7,18 +7,97 @@ RSpec.describe Seasonable do
 
   let!(:mock_locations) {{games: mock_games_data, teams: team_data, game_teams: mock_game_teams_data}}
 
-  let!(:stat_tracker) { StatTracker.from_csv(mock_locations) }
+  let!(:season_1213) { SeasonStatistics.from_csv(mock_locations, "20122013") }
+  let!(:season_1516) { SeasonStatistics.from_csv(mock_locations, "20152016") }
 
   it '#games_by_season' do
-    expect(stat_tracker.games_by_season("20122013")).to include("2012030132")
-    expect(stat_tracker.games_by_season("20122013")).to include("2012030323")
-    expect(stat_tracker.games_by_season("20142015")).to include("2014030315")
-    expect(stat_tracker.games_by_season("20152016")).to include("2015020975")
+    expect(season_1213.games_by_season("20122013")).to include("2012030132")
+    expect(season_1516.games_by_season("20152016")).to include("2015020975")
   end
 
   it '#coaches_by_season' do
-    expect(stat_tracker.coaches_by_season("20122013")).to include(:"Dan Bylsma")
-    expect(stat_tracker.coaches_by_season("20152016")).to include(:"Paul Maurice")
+    expect(season_1213.coaches_by_season("20122013")).to include(:"Dan Bylsma")
+    expect(season_1516.coaches_by_season("20152016")).to include(:"Paul Maurice")
+  end
+
+  it '#coach_records' do
+    expect(season_1213.coach_records("20122013")).to include(:"John Tortorella"=>{:wins=>0, :total_games=>0})
+    expect(season_1516.coach_records("20152016")).to include(:"Lindy Ruff"=>{:wins=>0, :total_games=>0})
+  end
+
+  # it '#process_coach_records' do
+  #   expect(season_1213.games_by_season("20122013")).to include("2012030132")
+  #   expect(season_1516.games_by_season("20152016")).to include("2015020975")
+  # end
+
+  # it '#process_coach_record' do
+  #   expect(season_1213.games_by_season("20122013")).to include("2012030132")
+  #   expect(season_1516.games_by_season("20152016")).to include("2015020975")
+  # end
+
+  # it '#winning_record' do
+  #   expect(season_1213.games_by_season("20122013")).to include("2012030132")
+  #   expect(season_1516.games_by_season("20152016")).to include("2015020975")
+  # end
+
+  it '#accuracy_records' do
+    expect(season_1213.accuracy_records("20122013")).to include(:"2"=>{:shots=>0, :goals=>0})
+    expect(season_1516.accuracy_records("20152016")).to include(:"25"=>{:shots=>0, :goals=>0})
+  end
+
+  # it '#populate_accuracy_records' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  # it '#process_accuracy_records' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  # it '#most_accurate' do
+  # expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  # it '#least_accurate' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  it '#tackle_records' do
+    expect(season_1213.tackle_records("20122013")).to include(:"3"=>0)
+    expect(season_1516.tackle_records("20152016")).to include(:"25"=>0)
+  end
+
+  # it '#populate_tackle_records' do
+  #   expect(season_1213.games_by_season).to include(:"3"=>0)
+  #   expect(season_1516.games_by_season).to include(:"25"=>0)
+  # end
+
+  # it '#process_tackle_record' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  # it '#best_tackling_team' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  # it '#worst_tackling_team' do
+  #   expect(season_1213.games_by_season).to include("2012030132")
+  #   expect(season_1516.games_by_season).to include("2015020975")
+  # end
+
+  it '#teams_by_season' do
+    expect(season_1213.teams_by_season("20122013")).to include(:"5")
+    expect(season_1516.teams_by_season("20152016")).to include(:"25")
+  end
+
+  it '#find_team_name_by_id_number' do
+    expect(season_1213.find_team_name_by_id(:"3")).to eq("Houston Dynamo")
+    expect(season_1516.find_team_name_by_id(:"25")).to include("Chicago Red Stars")
   end
 end
 

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe SeasonStatistics do 
+  mock_games_data = './data/mock_games.csv' 
+  team_data = './data/teams.csv' 
+  mock_game_teams_data = './data/mock_game_teams.csv' 
+  
+  let!(:mock_locations) {{games: mock_games_data, teams: team_data, game_teams: mock_game_teams_data}}
+
+  let!(:season_1213) { SeasonStatistics.from_csv(mock_locations, "20122013") }
+  let!(:season_1516) { SeasonStatistics.from_csv(mock_locations, "20152016") }
+
+  context 'season statistics' do 
+
+    it '#winningest_coach' do
+      require 'pry'; binding.pry
+      expect(season_1213.winningest_coach).to eq("Adam Oates")
+      expect(season_1516.winningest_coach).to eq("Lindy Ruff")
+    end
+
+    it '#worst_coach' do
+      expect(season_1213.worst_coach).to eq("John Tortorella")
+      expect(season_1516.worst_coach).to eq("Paul Maurice")
+    end
+
+    it '#most_accurate_team' do
+      expect(season_1213.most_accurate_team).to eq("Portland Timbers")
+      expect(season_1516.most_accurate_team).to eq("Chicago Red Stars")
+    end
+
+    it '#least_accurate_team' do
+      expect(season_1213.least_accurate_team).to eq("Houston Dynamo")
+      expect(season_1516.least_accurate_team).to eq("Portland Thorns FC")
+    end
+
+    it '#most_tackles' do
+      expect(season_1213.most_tackles).to eq("Seattle Sounders FC")
+      expect(season_1516.most_tackles).to eq("Chicago Red Stars")
+    end
+
+    it '#fewest_tackles' do
+      expect(season_1213.fewest_tackles).to eq("Portland Timbers")
+      expect(season_1516.fewest_tackles).to eq("Portland Thorns FC")
+    end
+
+  end
+end


### PR DESCRIPTION
Broke SeasonStatistics into it's own class, along with tests. I'm not convinced that this current version will work. It works in a self-contained way but it doesn't really function as a child of stat_tracker and I'm not sure the spec harness will like it. Needs work, but safe to merge at the moment.